### PR TITLE
采用 spring-boot-maven-plugin 插件

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,4 +57,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
demo中采用 spring-boot-maven-plugin 插件，参见 [issue #3](https://github.com/Wechat-Group/weixin-java-open-demo/issues/3)