### PR TITLE
fix - 修复Double Check Locking在初始化jedis pool中的错误用法

### DIFF
--- a/src/main/java/com/github/binarywang/demo/wx/open/service/WxOpenServiceDemo.java
+++ b/src/main/java/com/github/binarywang/demo/wx/open/service/WxOpenServiceDemo.java
@@ -2,15 +2,9 @@ package com.github.binarywang.demo.wx.open.service;
 
 import com.github.binarywang.demo.wx.open.config.RedisProperies;
 import com.github.binarywang.demo.wx.open.config.WechatOpenProperties;
-import me.chanjar.weixin.common.error.WxErrorException;
-import me.chanjar.weixin.common.session.WxSessionManager;
-import me.chanjar.weixin.mp.api.WxMpService;
-import me.chanjar.weixin.mp.bean.message.WxMpXmlMessage;
-import me.chanjar.weixin.mp.bean.message.WxMpXmlOutMessage;
 import me.chanjar.weixin.open.api.impl.WxOpenInRedisConfigStorage;
-import me.chanjar.weixin.open.api.impl.WxOpenServiceImpl;
-import me.chanjar.weixin.mp.api.WxMpMessageHandler;
 import me.chanjar.weixin.open.api.impl.WxOpenMessageRouter;
+import me.chanjar.weixin.open.api.impl.WxOpenServiceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +13,6 @@ import org.springframework.stereotype.Service;
 import redis.clients.jedis.JedisPool;
 
 import javax.annotation.PostConstruct;
-import java.util.Map;
 
 /**
  * @author <a href="https://github.com/007gzs">007</a>
@@ -32,7 +25,7 @@ public class WxOpenServiceDemo extends WxOpenServiceImpl {
     private WechatOpenProperties wechatOpenProperties;
     @Autowired
     private RedisProperies redisProperies;
-    private static JedisPool pool;
+    private volatile static JedisPool pool;
     private WxOpenMessageRouter wxOpenMessageRouter;
 
     @PostConstruct


### PR DESCRIPTION
根据 [The "Double-Checked Locking is Broken" Declaration](https://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html) 所述，DCL 只有在搭配 volatile 的时候才有效。此项目中错误使用了 DCL，有两种修复方案：

- 1. 不使用 DCL，`getJedisPool` 仅在单例对象`WxOpenServiceDemo`初始化的时候调用了一次，没有多线程下的多次初始化风险
- 2. 给 `pool` 字段加上 `volatile` 修饰

为了保持代码原意，保留DCL，选用方法2修复